### PR TITLE
Added udev rule for Joy-IT 7 inch touchscreen (RB-LCD-7-2)

### DIFF
--- a/rules/70-touchscreen-joy-it.rules
+++ b/rules/70-touchscreen-joy-it.rules
@@ -1,0 +1,7 @@
+SUBSYSTEMS=="usb",ACTION=="add",KERNEL=="event*",ATTRS{idVendor}=="0483",ATTRS{idProduct}=="5750",SYMLINK+="twofingtouch",RUN+="/bin/chmod a+r /dev/twofingtouch"
+
+#KERNEL=="event*",ATTRS{iProduct}=="ByQDtech 触控USB鼠标",SYMLINK+="twofingtouch",RUN+="/bin/chmod a+r /dev/twofingtouch"
+#KERNEL=="event*",ATTRS{name}=="深圳市全动电子技术有限公司",SYMLINK+="twofingtouch",RUN+="/bin/chmod a+r /dev/twofingtouch"
+
+KERNEL=="event*",ATTRS{idVendor}=="0483",ATTRS{idProduct}=="5750",SYMLINK+="twofingtouch",RUN+="/bin/chmod a+r /dev/twofingtouch"
+


### PR DESCRIPTION
Hello @Plippo 

This pull request contains an udev rule for the "ByQDtech 触控USB鼠标" 7\" touchscreen
sold by Joy-IT as RB-LCD-7-2.

Thank you!
